### PR TITLE
Skip setting multi-value headers for bad requests

### DIFF
--- a/src/ngx_http_lua_headers_in.c
+++ b/src/ngx_http_lua_headers_in.c
@@ -263,11 +263,6 @@ retry:
 
 new_header:
 
-    if (r->headers_in.headers.last == NULL) {
-        /* must be 400 bad request */
-        return NGX_OK;
-    }
-
     h = ngx_list_push(&r->headers_in.headers);
 
     if (h == NULL) {
@@ -697,6 +692,11 @@ ngx_http_lua_set_input_header(ngx_http_request_t *r, ngx_str_t key,
         return NGX_ERROR;
     }
 #endif
+
+    if (r->headers_out.status == 400 || r->headers_in.headers.last == NULL) {
+        /* must be a 400 Bad Request */
+        return NGX_OK;
+    }
 
     return hv.handler(r, &hv, &value);
 }

--- a/t/028-req-header.t
+++ b/t/028-req-header.t
@@ -8,7 +8,7 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (2 * blocks() + 30);
+plan tests => repeat_each() * (2 * blocks() + 31);
 
 #no_diff();
 #no_long_string();
@@ -1622,3 +1622,24 @@ ok
 --- no_error_log
 [error]
 --- no_check_leak
+
+
+
+=== TEST 54: for bad requests causing segfaults when setting & getting multi-value headers
+--- config
+    error_page 400 = /err;
+
+    location = /err {
+        content_by_lua_block {
+            ngx.req.set_header("Cookie", "foo=bar")
+            local test = ngx.var.cookie_bar
+
+            ngx.say("ok")
+        }
+    }
+--- raw_request
+GeT / HTTP/1.1
+--- response_body
+ok
+--- no_error_log
+[error]


### PR DESCRIPTION
Opening this PR so we can build an Nginx with this patch until https://github.com/openresty/lua-nginx-module/pull/844 is merged.

**Description**:
When setting a multi-value header during bad requests, the value isn't added into the header's array. Despite failing to be set, the size of the array is [still incremented](https://github.com/openresty/lua-nginx-module/blob/7d242ff79a63bae15c8f5f68999dfe5f4da7cf67/src/ngx_http_lua_headers_in.c#L624). Later, if Nginx attempts to [iterate over the array](https://github.com/nginx/nginx/blob/8d0b75f716f3ef2c33d277f70f45fbc1e0ca31fe/src/http/ngx_http_parse.c#L1922-L1931), a segfault will occur.

e21d9b5 established a pattern of silently ignoring the header being set. I've moved the check for a bad request into `ngx_http_lua_set_input_header` so that setting a header value is ignored for both types of headers.

r: @shivnagarajan @pushrax @stefanmb @fbogsany @csfrancis
